### PR TITLE
Convert remaining luadata serialization to use lua_wrangler.luaify

### DIFF
--- a/combiner.py
+++ b/combiner.py
@@ -3,9 +3,7 @@ import datetime
 import requests
 import json
 import urllib
-import luadata
 import sys
-# python -m pip install --upgrade luadata
 # These ones are from the same directory.
 import lua_wrangler
 import article_fetcher
@@ -217,24 +215,8 @@ if output_json == True:
   g.write(json.dumps(lua_json, indent=2))
   g.close()
 
-output = str(lua_json)
-# Now for the truly hoopty nonsense.
-
-outputtwo = luadata.serialize(lua_json, encoding="utf-8", indent="\t", indent_level=1)
-outputtwo = "return " + outputtwo
-
-# Make the sub-lists for tags be on one line instead of indented quadrice on multiple lines.
-outputtwo = outputtwo.replace('\n\t\t\t\t"', ' "')
-# Replace "tab tab {" with "tab {"
-outputtwo = outputtwo.replace("\n\t\t{", "\n\t{")
-# Replace "tab tab tab }" for sub-lists with normal closing brace.
-outputtwo = outputtwo.replace("\n\t\t\t}", " }")
-# De-indent individual items in 
-outputtwo = outputtwo.replace("\n\t\t\t", "\n\t\t")
-#print(outputtwo)
-
 h = open("combined/lua-" + str(combine_year) + ".txt", "w")
-h.write(str(outputtwo))
+h.write("return " + lua_wrangler.luaify(lua_json))
 h.close()
 if output_json == True:
   print("Success: combined/combine-" + str(combine_year) + ".json and combined/lua-" + str(combine_year) + ".txt")

--- a/main.py
+++ b/main.py
@@ -3,9 +3,9 @@ import datetime
 import requests
 import json
 import urllib
-import luadata
 import sys
-# python -m pip install --upgrade luadata
+
+import lua_wrangler
 
 headers = {"User-Agent": "JPxG's hoopty script (https://en.wikipedia.org/wiki/User:JPxG)"}
 
@@ -1342,7 +1342,7 @@ f = open("indytwo.txt", "w")
 f.write(str(output))
 f.close()
 
-outputtwo = luadata.serialize(indytwo, encoding="utf-8", indent="\t", indent_level=0)
+outputtwo = lua_wrangler.luaify(indytwo)
 
 print(outputtwo)
 


### PR DESCRIPTION
There were two remaining instances of luadata.serialize: one in main.py and one in combiner.py. This commit converts these instances to use lua_wrangler.luaify, which will mean that Signpost index modules are written with the same whitespace as [[WP:SPT]].