### PR TITLE
Do not escape non-ASCII characters in Lua strings

### DIFF
--- a/lua_serializer.py
+++ b/lua_serializer.py
@@ -32,7 +32,7 @@ LUA_RESTRICTED_TOKENS = {
 def make_lua_string(s):
     if not isinstance(s, str):
         raise TypeError(f"make_lua_string expects strings ({type(s).__name__} given)")
-    return json.dumps(s)
+    return json.dumps(s, ensure_ascii=False)
 
 
 lua_name_regex = re.compile("[_a-zA-Z][_a-zA-Z0-9]*")  # Basic Lua name requirements

--- a/test/test_lua_serializer.py
+++ b/test/test_lua_serializer.py
@@ -13,6 +13,7 @@ import lua_wrangler
         ('"foo"', r'"\"foo\""'),
         (r"\"", r'"\\\""'),
         ("foo\nbar", '"foo\\nbar"'),
+        ("über", '"über"'),
     ],
 )
 def test_make_lua_string(text, expected):


### PR DESCRIPTION
Using Unicode escape strings is unnecessary, harder to read, and Unicode escape strings also appear to be mangled by [[WP:SPT]].